### PR TITLE
Add automatic app version upgrades

### DIFF
--- a/dotnet/Endurance.API/AppVersionProvider.cs
+++ b/dotnet/Endurance.API/AppVersionProvider.cs
@@ -1,0 +1,47 @@
+using System.Text.RegularExpressions;
+using NuGet.Versioning;
+
+public class AppVersionProvider : IAppVersionProvider
+{
+    private readonly object _lock = new();
+    private SemanticVersion _current;
+
+    public AppVersionProvider(string initialVersion)
+    {
+        _current = SemanticVersion.Parse(initialVersion);
+    }
+
+    public string GetCurrent()
+    {
+        lock (_lock)
+        {
+            return _current.ToNormalizedString();
+        }
+    }
+
+    private static readonly Regex VersionRegex = new(@"\d+\.\d+\.\d+", RegexOptions.Compiled);
+
+    public bool TryUpdateFromServer(string validAppVersions)
+    {
+        if (string.IsNullOrWhiteSpace(validAppVersions))
+            return false;
+
+        // Example incoming value: ">= 6.18.0"
+        var match = VersionRegex.Match(validAppVersions);
+        if (!match.Success)
+            return false;
+
+        var required = SemanticVersion.Parse(match.Value);
+
+        lock (_lock)
+        {
+            if (required > _current)
+            {
+                _current = required;
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/dotnet/Endurance.API/CustomHeadersHandler.cs
+++ b/dotnet/Endurance.API/CustomHeadersHandler.cs
@@ -1,30 +1,135 @@
-﻿using Endurance.API.Services;
+﻿using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Endurance.API.Services;
 
 namespace Endurance.API;
 
-public class CustomHeadersHandler(IServiceProvider serviceProvider) : DelegatingHandler
+public class CustomHeadersHandler(
+    IServiceProvider serviceProvider,
+    IAppVersionProvider appVersionProvider,
+    ILogger<CustomHeadersHandler> logger) : DelegatingHandler
 {
     private readonly string _tokenEndpoint = "/session";
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        // Check if the request is not for the token endpoint
-        if (!request.RequestUri.AbsolutePath.EndsWith(_tokenEndpoint))
+        var isTokenRequest = request.RequestUri?.AbsolutePath.EndsWith(_tokenEndpoint) == true;
+
+        var attempt = await request.CloneAsync(cancellationToken).ConfigureAwait(false);
+        await PrepareRequestAsync(attempt, isTokenRequest).ConfigureAwait(false);
+
+        var response = await base.SendAsync(attempt, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode == (HttpStatusCode)426 &&
+            await TryUpdateVersionFromResponseAsync(response, request).ConfigureAwait(false))
+        {
+            response.Dispose();
+
+            var retry = await request.CloneAsync(cancellationToken).ConfigureAwait(false);
+            await PrepareRequestAsync(retry, isTokenRequest).ConfigureAwait(false);
+
+            return await base.SendAsync(retry, cancellationToken).ConfigureAwait(false);
+        }
+
+        return response;
+    }
+
+    private async Task PrepareRequestAsync(HttpRequestMessage request, bool isTokenRequest)
+    {
+        if (!isTokenRequest)
         {
             if (serviceProvider.GetService(typeof(TokenService)) is TokenService tokenService)
             {
-                var token = await tokenService.GetTokenAsync();
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                var token = await tokenService.GetTokenAsync().ConfigureAwait(false);
+                request.Headers.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
 
-            request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Accept.Add(
+                new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
         }
 
+        var appVersion = appVersionProvider.GetCurrent();
+
+        request.Headers.Remove("App-Version");
+        request.Headers.TryAddWithoutValidation("App-Version", appVersion);
         request.Headers.TryAddWithoutValidation("User-Agent", "okhttp/4.12.0");
         request.Headers.TryAddWithoutValidation("Api-Version", "100.a");
-        request.Headers.TryAddWithoutValidation("App-Version", "6.17.0");
         request.Headers.TryAddWithoutValidation("Device-Id", "cmrmH-2PR463YAiI7xEV-i");
+    }
 
-        return await base.SendAsync(request, cancellationToken);
+    private async Task<bool> TryUpdateVersionFromResponseAsync(HttpResponseMessage response, HttpRequestMessage originalRequest)
+    {
+        try
+        {
+            var previousVersion = appVersionProvider.GetCurrent();
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            var versionInfo = JsonSerializer.Deserialize<VersionResponse>(
+                content,
+                new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+            if (versionInfo?.ValidAppVersions is null)
+            {
+                logger.LogWarning(
+                    "Received 426 (Upgrade Required) for {Method} {Uri}, but 'valid_app_versions' was missing. Current App-Version: {AppVersion}",
+                    originalRequest.Method,
+                    originalRequest.RequestUri,
+                    previousVersion);
+
+                return false;
+            }
+
+            var updated = appVersionProvider.TryUpdateFromServer(versionInfo.ValidAppVersions);
+
+            if (updated)
+            {
+                var newVersion = appVersionProvider.GetCurrent();
+
+                logger.LogWarning(
+                    "Received 426 (Upgrade Required) for {Method} {Uri}. App-Version {PreviousVersion} is outdated. " +
+                    "Server valid_app_versions: \"{ValidAppVersions}\". Updating to App-Version {NewVersion} and retrying once.",
+                    originalRequest.Method,
+                    originalRequest.RequestUri,
+                    previousVersion,
+                    versionInfo.ValidAppVersions,
+                    newVersion);
+
+                return true;
+            }
+
+            logger.LogWarning(
+                "Received 426 (Upgrade Required) for {Method} {Uri}, but App-Version {AppVersion} could not be updated from server response 'valid_app_versions': \"{ValidAppVersions}\".",
+                originalRequest.Method,
+                originalRequest.RequestUri,
+                previousVersion,
+                versionInfo.ValidAppVersions);
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to process 426 (Upgrade Required) response for {Method} {Uri}. Current App-Version: {AppVersion}",
+                originalRequest.Method,
+                originalRequest.RequestUri,
+                appVersionProvider.GetCurrent());
+
+            return false;
+        }
+    }
+
+    private sealed class VersionResponse
+    {
+        [JsonPropertyName("app_version")]
+        public string? AppVersion { get; set; }
+
+        [JsonPropertyName("valid_app_versions")]
+        public string? ValidAppVersions { get; set; }
     }
 }

--- a/dotnet/Endurance.API/Endurance.API.csproj
+++ b/dotnet/Endurance.API/Endurance.API.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
         <PackageReference Include="ntfy" Version="0.5.0" />
+        <PackageReference Include="NuGet.Versioning" Version="7.0.0" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
         <PackageReference Include="Refit" Version="7.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />

--- a/dotnet/Endurance.API/Extensions/HttpRequestMessageExtensions.cs
+++ b/dotnet/Endurance.API/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,38 @@
+public static class HttpRequestMessageExtensions
+{
+    public static async Task<HttpRequestMessage> CloneAsync(
+        this HttpRequestMessage request,
+        CancellationToken cancellationToken = default)
+    {
+        var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+        {
+            Version = request.Version
+        };
+
+        if (request.Content != null)
+        {
+            var ms = new MemoryStream();
+            await request.Content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+            ms.Position = 0;
+
+            clone.Content = new StreamContent(ms);
+
+            foreach (var header in request.Content.Headers)
+            {
+                clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        foreach (var header in request.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        foreach (var option in request.Options)
+        {
+            clone.Options.Set(new HttpRequestOptionsKey<object?>(option.Key), option.Value);
+        }
+
+        return clone;
+    }
+}

--- a/dotnet/Endurance.API/Interfaces/IAppVersionProvider.cs
+++ b/dotnet/Endurance.API/Interfaces/IAppVersionProvider.cs
@@ -1,0 +1,5 @@
+public interface IAppVersionProvider
+{
+    string GetCurrent();
+    bool TryUpdateFromServer(string validAppVersions);
+}


### PR DESCRIPTION
As mentioned in #2 the Electrolyte returns a 426 whenever they release a new app version. Previously I manually updated the `app_version` that Endurance sends in the headers of the request. This PR solves that and will automatically retry the request with the version provided in the "valid_app_version" field of the Electrolyte response and keep that version in memory for all upcoming requests. 

This means I won't have to manually upgrade the app version anymore and it will stop Endurance from breaking.

Fixes #2 