### PR TITLE
Improve formatting in email template

### DIFF
--- a/dotnet/Endurance.API/Models/EmailTemplate/BasicEmailTemplate.cs
+++ b/dotnet/Endurance.API/Models/EmailTemplate/BasicEmailTemplate.cs
@@ -80,17 +80,8 @@ public static class BasicEmailTemplate
     text-decoration: none !important;
   }
 
-        .row {
-            display: flex;
-            justify-content: space-between;
-            padding: 10px 0;
-            border-bottom: 1px solid #e0e0e0;
-        }
         .label {
             font-weight: bold;
-        }
-        .value {
-            text-align: right;
         }
 
   #MessageViewBody a {
@@ -121,28 +112,30 @@ public static class BasicEmailTemplate
 <h2>Endurance</h2>
                   <p style=""font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;"">Hi there,</p>
                   <p style=""font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;"">You're receiving this email because you've subscribed to get notifications for a class at SportCity. We want to let you know that there's a spot available for the following class: </p>
-                  <table role=""presentation"" border=""0"" cellpadding=""0"" cellspacing=""0"" class=""btn btn-primary"" style=""border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%; min-width: 100%;"" width=""100%"">
+                  <table role=""presentation"" border=""0"" cellpadding=""0"" cellspacing=""0"" style=""border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%; min-width: 100%;"" width=""100%"">
                     <tbody>
                       <tr>
-                        <td align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top; padding-bottom: 16px;"" valign=""top"">
-                          <table role=""presentation"" border=""0"" cellpadding=""0"" cellspacing=""0"" style=""border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;"">
-                            <tbody>
-                              <tr>
-                                <div class=""row"">
-            <div class=""label"">Activity</div>
-            <div class=""value"">{ActivityName}</div>
-        </div>
-        <div class=""row"">
-            <div class=""label"">Day</div>
-            <div class=""value"">{Day} at {Time}</div>
-        </div>
-        <div class=""row"">
-            <div class=""label"">Venue</div>
-            <div class=""value"">{Venue}</div>
-        </div>
-                              </tr>
-                            </tbody>
-                          </table>
+                        <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
+                          Activity:
+                        </td>
+                        <td class=""value"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
+                          {ActivityName}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
+                          Day:
+                        </td>
+                        <td class=""value"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
+                          {Day} at {Time}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
+                          Venue:
+                        </td>
+                        <td class=""value"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
+                          {Venue}
                         </td>
                       </tr>
                     </tbody>

--- a/dotnet/Endurance.API/Models/EmailTemplate/BasicEmailTemplate.cs
+++ b/dotnet/Endurance.API/Models/EmailTemplate/BasicEmailTemplate.cs
@@ -123,7 +123,7 @@ public static class BasicEmailTemplate
                     <tbody>
                       <tr>
                         <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
-                          Activity:
+                          Activity
                         </td>
                         <td class=""value"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
                           {ActivityName}
@@ -131,7 +131,7 @@ public static class BasicEmailTemplate
                       </tr>
                       <tr>
                         <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
-                          Day:
+                          Day
                         </td>
                         <td class=""value"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
                           {Day} at {Time}
@@ -139,7 +139,7 @@ public static class BasicEmailTemplate
                       </tr>
                       <tr>
                         <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
-                          Venue:
+                          Venue
                         </td>
                         <td class=""value"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">
                           {Venue}

--- a/dotnet/Endurance.API/Models/EmailTemplate/BasicEmailTemplate.cs
+++ b/dotnet/Endurance.API/Models/EmailTemplate/BasicEmailTemplate.cs
@@ -80,8 +80,15 @@ public static class BasicEmailTemplate
     text-decoration: none !important;
   }
 
+        .details-table td {
+            padding: 10px 0;
+            border-bottom: 1px solid #e0e0e0;
+        }
         .label {
             font-weight: bold;
+        }
+        .value {
+            text-align: right;
         }
 
   #MessageViewBody a {
@@ -112,7 +119,7 @@ public static class BasicEmailTemplate
 <h2>Endurance</h2>
                   <p style=""font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;"">Hi there,</p>
                   <p style=""font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;"">You're receiving this email because you've subscribed to get notifications for a class at SportCity. We want to let you know that there's a spot available for the following class: </p>
-                  <table role=""presentation"" border=""0"" cellpadding=""0"" cellspacing=""0"" style=""border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%; min-width: 100%;"" width=""100%"">
+                  <table class=""details-table"" role=""presentation"" border=""0"" cellpadding=""0"" cellspacing=""0"" style=""border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%; min-width: 100%;"" width=""100%"">
                     <tbody>
                       <tr>
                         <td class=""label"" align=""left"" style=""font-family: Helvetica, sans-serif; font-size: 16px; vertical-align: top;"" valign=""top"">


### PR DESCRIPTION
I've discovered your project this week after trying to create something like this myself and looking for something like it a couple of times before. Awesome work!

I just received my first notification e-mail and I noticed a couple of things that could be improved:
* while the table with the class-details does not link to anything, it got a red background on mouseover.
* the label and value of the details in the table were not seperated by a space or another character.

What I've done:
* Unwrapped the double-nested table with the details
* Converted the divs with rows, label and value classes into table-rows and -columns
* Removed the `btn` class from the table, so it doesn't get a hover state anymore.

Before:  
<img width="652" height="551" alt="image" src="https://github.com/user-attachments/assets/6a8e8427-e39d-44c3-b5bf-a82547e4abf6" />


After:  
<img width="652" height="484" alt="image" src="https://github.com/user-attachments/assets/327b993b-01b5-425a-934e-db85fefa5962" />
